### PR TITLE
Marks in non tasks LI blocks must cast to None

### DIFF
--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -433,11 +433,20 @@ static int GenericParser_block(MD_BLOCKTYPE type, void *detail,
                         mark_delimiter);
             break;
         case MD_BLOCK_LI:
-            arglist = Py_BuildValue("(O{s:i,s:C,s:i})", get_enum_blocktype(type),
-                    "is_task", ((MD_BLOCK_LI_DETAIL *) detail)->is_task,
-                    "task_mark", ((MD_BLOCK_LI_DETAIL *) detail)->task_mark,
-                    "task_mark_offset", ((MD_BLOCK_LI_DETAIL *) detail)->
-                        task_mark_offset);
+            // Tasks can have marks, but marks in non tasks are undefined
+            if (((MD_BLOCK_LI_DETAIL *) detail)->is_task) {
+                arglist = Py_BuildValue("(O{s:i,s:C,s:i})", get_enum_blocktype(type),
+                        "is_task", ((MD_BLOCK_LI_DETAIL *) detail)->is_task,
+                        "task_mark", ((MD_BLOCK_LI_DETAIL *) detail)->task_mark,
+                        "task_mark_offset", ((MD_BLOCK_LI_DETAIL *) detail)->
+                            task_mark_offset);
+            } else {
+                arglist = Py_BuildValue("(O{s:i,s:O,s:i})", get_enum_blocktype(type),
+                        "is_task", ((MD_BLOCK_LI_DETAIL *) detail)->is_task,
+                        "task_mark", Py_None,
+                        "task_mark_offset", ((MD_BLOCK_LI_DETAIL *) detail)->
+                            task_mark_offset);
+            }
             break;
         case MD_BLOCK_H:
             arglist = Py_BuildValue("(O{s:i})", get_enum_blocktype(type),


### PR DESCRIPTION
Currently, tasks marks in non tasks `LI` blocks are returning `'\x00'` caracter, which is evaluated by Python as `True`.

The solution proposed here checks if a `LI` code is a task, and if is not a task, returns `None` in the field `task_mark` for the `details` parameter of the callback. As `md4c` source code comment points in [this line](https://github.com/mity/md4c/blob/440ccd82f3d93f558275e6037a52d9aff98527ab/src/md4c.h#L254): "If is_task, then one of 'x', 'X' or ' '. Undefined otherwise."

## Minimal reproducible example

```python
import md4c

def enter_block_callback(block, details):
    if block.value == md4c.BlockType.LI:
        print(details)
        print("Task mark: '%s'" % details["task_mark"], bool(details["task_mark"]))
        print()

def leave_block_callback(block, details):
    pass

def enter_span_callback(block, details):
    pass

def leave_span_callback(block, details):
    pass

def text_callback(block, text):
    pass


content = '''    
- Hello
- Bye

- [ ] Foo
- [x] Bar
'''
parser = md4c.GenericParser(md4c.MD_FLAG_TASKLISTS)
parser.parse(content,
             enter_block_callback,
             leave_block_callback,
             enter_span_callback,
             leave_span_callback,
             text_callback)
```

## Current output

```
{'is_task': 0, 'task_mark': '\x00', 'task_mark_offset': 0}
Task mark: '' True

{'is_task': 0, 'task_mark': '\x00', 'task_mark_offset': 0}
Task mark: '' True

{'is_task': 1, 'task_mark': ' ', 'task_mark_offset': 23}
Task mark: ' ' True

{'is_task': 1, 'task_mark': 'x', 'task_mark_offset': 33}
Task mark: 'x' True
```

## Output after this pull

```
{'is_task': 0, 'task_mark': None, 'task_mark_offset': 0}
Task mark: 'None' False

{'is_task': 0, 'task_mark': None, 'task_mark_offset': 0}
Task mark: 'None' False

{'is_task': 1, 'task_mark': ' ', 'task_mark_offset': 23}
Task mark: ' ' True

{'is_task': 1, 'task_mark': 'x', 'task_mark_offset': 33}
Task mark: 'x' True

```
