### PR TITLE
Make details more Pythonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,12 @@ handled quietly).
   Values are `int`s, single-character `str`s, or (for `MD_ATTRIBUTE`) lists of
   tuples or None.
 
-  See the `MD_BLOCK_*_DETAIL` and `MD_SPAN_*_DETAIL` structs in MD4C's `md4c.h`
-  for information on exactly what this `dict` will contain.
+  This dict will contain the information provided by `MD_BLOCK_*_DETAIL` and
+  `MD_SPAN_*_DETAIL` structs in MD4C's `md4c.h`, with following exceptions:
+
+  * Non tasks `MD_BLOCK_LI` blocks (when `is_task` detail is `False`) do not
+    include `task_mark` and `task_mark_offset` attributes.
+  * Indented `MD_BLOCK_CODE` blocks do not include the `fence_char` attribute.
 
   Regarding `MD_ATTRIBUTE`s: These are used where a block or span can contain
   some associated text, such as link titles and code block language references.

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -420,12 +420,12 @@ static int GenericParser_block(MD_BLOCKTYPE type, void *detail,
     PyObject *arglist;
     switch(type) {
         case MD_BLOCK_UL:
-            arglist = Py_BuildValue("(O{s:O,s:C})", get_enum_blocktype(type),
+            arglist = Py_BuildValue("(O{s:N,s:C})", get_enum_blocktype(type),
                     "is_tight", PyBool_FromLong(((MD_BLOCK_UL_DETAIL *) detail)->is_tight),
                     "mark", ((MD_BLOCK_UL_DETAIL *) detail)->mark);
             break;
         case MD_BLOCK_OL:
-            arglist = Py_BuildValue("(O{s:i,s:O,s:C})",
+            arglist = Py_BuildValue("(O{s:i,s:N,s:C})",
                     get_enum_blocktype(type),
                     "start", ((MD_BLOCK_OL_DETAIL *) detail)->start,
                     "is_tight", PyBool_FromLong(((MD_BLOCK_OL_DETAIL *) detail)->is_tight),

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -420,37 +420,50 @@ static int GenericParser_block(MD_BLOCKTYPE type, void *detail,
     PyObject *arglist;
     switch(type) {
         case MD_BLOCK_UL:
-            arglist = Py_BuildValue("(O{s:i,s:C})", get_enum_blocktype(type),
-                    "is_tight", ((MD_BLOCK_UL_DETAIL *) detail)->is_tight,
+            arglist = Py_BuildValue("(O{s:O,s:C})", get_enum_blocktype(type),
+                    "is_tight", PyBool_FromLong(((MD_BLOCK_UL_DETAIL *) detail)->is_tight),
                     "mark", ((MD_BLOCK_UL_DETAIL *) detail)->mark);
             break;
         case MD_BLOCK_OL:
-            arglist = Py_BuildValue("(O{s:i,s:i,s:C})",
+            arglist = Py_BuildValue("(O{s:i,s:O,s:C})",
                     get_enum_blocktype(type),
                     "start", ((MD_BLOCK_OL_DETAIL *) detail)->start,
-                    "is_tight", ((MD_BLOCK_OL_DETAIL *) detail)->is_tight,
+                    "is_tight", PyBool_FromLong(((MD_BLOCK_OL_DETAIL *) detail)->is_tight),
                     "mark_delimiter", ((MD_BLOCK_OL_DETAIL *) detail)->
                         mark_delimiter);
             break;
         case MD_BLOCK_LI:
-            arglist = Py_BuildValue("(O{s:i,s:C,s:i})", get_enum_blocktype(type),
-                    "is_task", ((MD_BLOCK_LI_DETAIL *) detail)->is_task,
-                    "task_mark", ((MD_BLOCK_LI_DETAIL *) detail)->task_mark,
-                    "task_mark_offset", ((MD_BLOCK_LI_DETAIL *) detail)->
-                        task_mark_offset);
+            if (((MD_BLOCK_LI_DETAIL *) detail)->is_task) {
+                arglist = Py_BuildValue("(O{s:O,s:C,s:i})", get_enum_blocktype(type),
+                        "is_task", Py_True,
+                        "task_mark", ((MD_BLOCK_LI_DETAIL *) detail)->task_mark,
+                        "task_mark_offset", ((MD_BLOCK_LI_DETAIL *) detail)->
+                            task_mark_offset);
+            } else {
+                arglist = Py_BuildValue("(O{s:O})", get_enum_blocktype(type),
+                        "is_task", Py_False);
+            }
             break;
         case MD_BLOCK_H:
             arglist = Py_BuildValue("(O{s:i})", get_enum_blocktype(type),
                     "level", ((MD_BLOCK_H_DETAIL *) detail)->level);
             break;
         case MD_BLOCK_CODE:
-            arglist = Py_BuildValue("(O{s:O,s:O,s:C})", get_enum_blocktype(type),
-                    "info", GenericParser_md_attribute(
-                        &((MD_BLOCK_CODE_DETAIL *) detail)->info),
-                    "lang", GenericParser_md_attribute(
-                        &((MD_BLOCK_CODE_DETAIL *) detail)->lang),
-                    "fence_char", ((MD_BLOCK_CODE_DETAIL *) detail)->
-                        fence_char);
+            if (((MD_BLOCK_CODE_DETAIL *) detail)->fence_char == NULL) {
+                arglist = Py_BuildValue("(O{s:O,s:O})", get_enum_blocktype(type),
+                        "info", GenericParser_md_attribute(
+                            &((MD_BLOCK_CODE_DETAIL *) detail)->info),
+                        "lang", GenericParser_md_attribute(
+                            &((MD_BLOCK_CODE_DETAIL *) detail)->lang));
+            } else {
+                arglist = Py_BuildValue("(O{s:O,s:O,s:C})", get_enum_blocktype(type),
+                        "info", GenericParser_md_attribute(
+                            &((MD_BLOCK_CODE_DETAIL *) detail)->info),
+                        "lang", GenericParser_md_attribute(
+                            &((MD_BLOCK_CODE_DETAIL *) detail)->lang),
+                        "fence_char", ((MD_BLOCK_CODE_DETAIL *) detail)->
+                            fence_char);
+            }
             break;
         case MD_BLOCK_TH:
         case MD_BLOCK_TD:


### PR DESCRIPTION
Closes #14

I've completed all the rules that you've included in the issue. The implementation have been tested using next script:

```python

import md4c

def enter_block_callback(block, details):
    print("ENTER BLOCK:", block.name, details)
    if block.value == md4c.BlockType.LI:
        assert isinstance(details['is_task'], bool)
        if not details['is_task']:
            assert 'task_mark' not in details
            assert 'task_mark_offset' not in details
    elif block.value == md4c.BlockType.CODE:
        if 'fence_char' in details:
            assert details['fence_char'] != '\x00'
    elif block.value == md4c.BlockType.OL:
        assert isinstance(details['is_tight'], bool)
    elif block.value == md4c.BlockType.UL:
        assert isinstance(details['is_tight'], bool)

def leave_block_callback(block, details):
    print("LEAVE BLOCK:", block.name, details)
    
def enter_span_callback(span, details):
    print("ENTER SPAN:", span.name, details)

def leave_span_callback(span, details):
    print("LEAVE SPAN:", span.name, details)

def text_callback(block, text):
    print("TEXT:", block.name, text)

markdown_text = '''
<!-- Taskslists -->
- [x] A solved task
- [x] Other solved task
- [ ] An unsolved task
- A list item

+ Other list item


<!-- Code blocks -->
~~~
Code block with fence char
~~~

    Indented code block


<!-- OL lists -->
1. Item in ordered list
2. Other item in ordered list


1. Item in second ordered list

2. Other item in second ordered list


<!-- UL lists -->
- Item in unordered list

- Another item in unordered list

+ Item in other unordered list
+ Another item in other unordered list
'''

generic_parser = md4c.GenericParser(
    md4c.MD_FLAG_TASKLISTS | md4c.MD_FLAG_NOHTMLBLOCKS)
generic_parser.parse(markdown_text,
                     enter_block_callback,
                     leave_block_callback,
                     enter_span_callback,
                     leave_span_callback,
                     text_callback)
```