### PR TITLE
Make GenericParser and HTMLRenderer accept flag kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,56 +230,43 @@ Module-Wide Constants
 ---------------------
 
 The MD4C library provides various option flags for parsers and renderers as
-named constants. These are made available as module-level constants in PyMD4C.
+named constants. These are made available as module-level constants in PyMD4C. Also, each constant has a correspondient optional keyword argument that can be used instanciating parser and renderers.
 
 ### Parser Option Flags
 
 Basic option flags:
 
-* `md4c.MD_FLAG_COLLAPSEWHITESPACE` - In normal text, collapse non-trivial
-  whitespace into a single space.
-* `md4c.MD_FLAG_PERMISSIVEATXHEADERS` - Do not requite a space in ATX headers
-  (e.g. `###Header`).
-* `md4c.MD_FLAG_PERMISSIVEURLAUTOLINKS` - Convert URLs to links even without
-  `<` and `>`.
-* `md4c.MD_FLAG_PERMISSIVEEMAILAUTOLINKS` - Convert email addresses to links
-  even without `<`, `>`, and `mailto:`.
-* `md4c.MD_FLAG_NOINDENTEDCODEBLOCKS` - Disable indented code blocks. (Only
-  allow fenced code blocks.)
-* `md4c.MD_FLAG_NOHTMLBLOCKS` - Disable raw HTML blocks.
-* `md4c.MD_FLAG_NOHTMLSPANS` - Disable raw HTML inlines.
-* `md4c.MD_FLAG_TABLES` - Enable tables extension.
-* `md4c.MD_FLAG_STRIKETHROUGH` - Enable strikethrough extension.
-* `md4c.MD_FLAG_PERMISSIVEWWWAUTOLINKS` - Enable www autolinks (even without
-  any scheme prefix, as long as they begin with `www.`).
-* `md4c.MD_FLAG_TASKLISTS` - Enable task lists extension.
-* `md4c.MD_FLAG_LATEXMATHSPANS` - Enable `$` and `$$` containing LaTeX
-  equations.
-* `md4c.MD_FLAG_WIKILINKS` - Enable wiki links extension.
-* `md4c.MD_FLAG_UNDERLINE` - Enable underline extension (and disable `_` for
-  regular emphasis).
+| md4c flag | keyword argument | description |
+| :-------- | :--------------- | :---------- |
+| `md4c.MD_FLAG_COLLAPSEWHITESPACE` | `collapse_whitespace` | In normal text, collapse non-trivial whitespace into a single space. |
+| `md4c.MD_FLAG_COLLAPSEWHITESPACE` | `permissive_atx_headers` | Do not requite a space in ATX headers (e.g. `###Header`). |
+| `md4c.MD_FLAG_PERMISSIVEURLAUTOLINKS` | `permissive_url_autolinks` | Convert URLs to links even without `<` and `>`. |
+| `md4c.MD_FLAG_PERMISSIVEEMAILAUTOLINKS` | `permissive_email_autolinks` | Convert email addresses to links even without `<`, `>`, and `mailto:`. |
+| `md4c.MD_FLAG_NOINDENTEDCODEBLOCKS` | `no_indented_code_blocks` | Disable indented code blocks (only allow fenced code blocks). |
+| `md4c.MD_FLAG_NOHTMLBLOCKS` | `no_html_blocks` | Disable raw HTML blocks. |
+| `md4c.MD_FLAG_NOHTMLSPANS` | `no_html_spans` | Disable raw HTML inlines. |
+| `md4c.MD_FLAG_TABLES` | `tables` | Enable tables extension. |
+| `md4c.MD_FLAG_STRIKETHROUGH` | `strikethrough` | Enable strikethrough extension. |
+| `md4c.MD_FLAG_PERMISSIVEWWWAUTOLINKS` | `permissive_www_autolinks` | Enable www autolinks (even without any scheme prefix, as long as they begin with `www.`).
+| `md4c.MD_FLAG_TASKLISTS` | `tasklists` | Enable task lists extension. |
+| `md4c.MD_FLAG_LATEXMATHSPANS` | `latex_math_spans` | Enable `$` and `$$` containing LaTeX equations. |
+| `md4c.MD_FLAG_WIKILINKS` | `wikilinks` | Enable wiki links extension. |
+| `md4c.MD_FLAG_UNDERLINE` | `underline` | Enable underline extension (and disable `_` for regular emphasis). |
 
 Combination option flags:
 
-* `md4c.MD_FLAG_PERMISSIVEAUTOLINKS` - Enables all varieties of autolinks:
-  `MD_FLAG_PERMISSIVEURLAUTOLINKS`, `MD_FLAG_PERMISSIVEEMAILAUTOLINKS`, and
-  `MD_FLAG_PERMISSIVEWWWAUTOLINKS`
-* `md4c.MD_FLAG_NOHTML` - Disables all raw HTML tags: `MD_FLAG_NOHTMLBLOCKS`
-  and `MD_FLAG_NOHTMLSPANS`
+| md4c flag | keyword argument | description |
+| :-------- | :--------------- | :---------- |
+| `md4c.MD_FLAG_PERMISSIVEAUTOLINKS` | `permissive_auto_links` | Enables all varieties of autolinks: `MD_FLAG_PERMISSIVEURLAUTOLINKS`, `MD_FLAG_PERMISSIVEEMAILAUTOLINKS`, and `MD_FLAG_PERMISSIVEWWWAUTOLINKS`. |
+| `md4c.MD_FLAG_NOHTML` | `no_html` | Disables all raw HTML tags: `MD_FLAG_NOHTMLBLOCKS` and `MD_FLAG_NOHTMLSPANS`. |
 
 Dialect option flags (note that not all features of a dialect may be supported,
 but these flags will cause MD4C to parse as many features of the dialect as it
 supports):
 
-* `md4c.MD_DIALECT_COMMONMARK` - This is the default behavior of MD4C, so no
-  additional flags are enabled.
-* `md4c.MD_DIALECT_GITHUB` - Parse GitHub-Flavored Markdown, which enables the
-  following flags:
-
-  - `MD_FLAG_PERMISSIVEAUTOLINKS`
-  - `MD_FLAG_TABLES`
-  - `MD_FLAG_STRIKETHROUGH`
-  - `MD_FLAG_TASKLISTS`
+| md4c flag | keyword argument | description |
+| :-------- | :--------------- | :---------- |
+| `md4c.MD_DIALECT_GITHUB` | `dialect_github` | Parse GitHub-Flavored Markdown, which enables the following flags:<br><br><ul><li><code>MD_FLAG_PERMISSIVEAUTOLINKS</code></li><li><code>MD_FLAG_TABLES</code></li><li><code>MD_FLAG_STRIKETHROUGH</code></li><li><code>MD_FLAG_TASKLISTS</code></li></ul>
 
 ### HTML Renderer Option Flags
 

--- a/README.md
+++ b/README.md
@@ -270,12 +270,12 @@ supports):
 
 ### HTML Renderer Option Flags
 
-* `md4c.MD_HTML_FLAG_DEBUG` - For development use, send MD4C debug output to
-  stderr.
-* `md4c.MD_HTML_FLAG_VERBATIM_ENTITIES` - Do not replace HTML entities with the
-  actual character (e.g. `&copy;` with ©).
-* `md4c.MD_HTML_FLAG_SKIP_UTF8_BOM` - Omit BOM from start of UTF-8 input.
-* `md4c.MD_HTML_FLAG_XHTML` - Generate XHTML instead of HTML.
+| md4c flag | keyword argument | description |
+| :-------- | :--------------- | :---------- |
+| `md4c.MD_HTML_FLAG_DEBUG` | `debug` | For development use, send MD4C debug output to stderr. |
+| `md4c.MD_HTML_FLAG_VERBATIM_ENTITIES` | `verbatim_entities` | Do not replace HTML entities with the actual character (e.g. `&copy;` with ©). |
+| `md4c.MD_HTML_FLAG_SKIP_UTF8_BOM` | `skip_utf8_bom` | Omit BOM from start of UTF-8 input. |
+| `md4c.MD_HTML_FLAG_XHTML` | `xhtml` | Generate XHTML instead of HTML. |
 
 Enums
 -----

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Module-Wide Constants
 ---------------------
 
 The MD4C library provides various option flags for parsers and renderers as
-named constants. These are made available as module-level constants in PyMD4C. Also, each constant has a correspondient optional keyword argument that can be used instanciating parser and renderers.
+named constants. These are made available as module-level constants in PyMD4C. Also, each constant has a correspondent optional keyword argument that can be used instanciating parser and renderers.
 
 ### Parser Option Flags
 

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -179,7 +179,7 @@ static int HTMLRenderer_init(HTMLRendererObject *self, PyObject *args,
         "xhtml",
         NULL,
     };
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|II$pppppppppppppppppppp",
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|II$ppppppppppppppppppppp",
                                      kwlist, &parser_flags, &renderer_flags,
                                      &collapse_whitespace,
                                      &permissive_atx_headers,

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -252,10 +252,105 @@ typedef struct {
 static int GenericParser_init(GenericParserObject *self, PyObject *args,
         PyObject *kwds) {
     unsigned int parser_flags = 0;
+    unsigned short int collapse_whitespace = 0;
+    unsigned short int permissive_atx_headers = 0;
+    unsigned short int permissive_url_autolinks = 0;
+    unsigned short int permissive_email_autolinks = 0;
+    unsigned short int no_indented_code_blocks = 0;
+    unsigned short int no_html_blocks = 0;
+    unsigned short int no_html_spans = 0;
+    unsigned short int tables = 0;
+    unsigned short int strikethrough = 0;
+    unsigned short int permissive_www_autolinks = 0;
+    unsigned short int tasklists = 0;
+    unsigned short int latex_math_spans = 0;
+    unsigned short int wikilinks = 0;
+    unsigned short int underline = 0;
     
-    static char *kwlist[] = {"parser_flags", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I", kwlist, &parser_flags)) {
+    static char *kwlist[] = {
+        "parser_flags",
+        "collapse_whitespace",
+        "permissive_atx_headers",
+        "permissive_url_autolinks",
+        "permissive_email_autolinks",
+        "no_indented_code_blocks",
+        "no_html_blocks",
+        "no_html_spans",
+        "tables",
+        "strikethrough",
+        "permissive_www_autolinks",
+        "tasklists",
+        "latex_math_spans",
+        "wikilinks",
+        "underline",
+        NULL
+    };
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I$pppppppppppppp", kwlist,
+                                     &parser_flags, &collapse_whitespace,
+                                     &permissive_atx_headers,
+                                     &permissive_url_autolinks,
+                                     &permissive_email_autolinks,
+                                     &no_indented_code_blocks, &no_html_blocks,
+                                     &no_html_spans, &tables, &strikethrough,
+                                     &permissive_www_autolinks, &tasklists,
+                                     &latex_math_spans, &wikilinks, &underline)) {
         return -1;
+    }
+    
+    if (collapse_whitespace && !(parser_flags & MD_FLAG_COLLAPSEWHITESPACE)) {
+        parser_flags += MD_FLAG_COLLAPSEWHITESPACE;
+    }
+    
+    if (permissive_atx_headers && !(parser_flags & MD_FLAG_PERMISSIVEATXHEADERS)) {
+        parser_flags += MD_FLAG_PERMISSIVEATXHEADERS;
+    }
+    
+    if (permissive_url_autolinks && !(parser_flags & MD_FLAG_PERMISSIVEURLAUTOLINKS)) {
+        parser_flags += MD_FLAG_PERMISSIVEURLAUTOLINKS;
+    }
+    
+    if (permissive_email_autolinks && !(parser_flags & MD_FLAG_PERMISSIVEEMAILAUTOLINKS)) {
+        parser_flags += MD_FLAG_PERMISSIVEEMAILAUTOLINKS;
+    }
+    
+    if (no_indented_code_blocks && !(parser_flags & MD_FLAG_NOINDENTEDCODEBLOCKS)) {
+        parser_flags += MD_FLAG_NOINDENTEDCODEBLOCKS;
+    }
+    
+    if (no_html_blocks && !(parser_flags & MD_FLAG_NOHTMLBLOCKS)) {
+        parser_flags += MD_FLAG_NOHTMLBLOCKS;
+    }
+    
+    if (no_html_spans && !(parser_flags & MD_FLAG_NOHTMLSPANS)) {
+        parser_flags += MD_FLAG_NOHTMLSPANS;
+    }
+    
+    if (tables && !(parser_flags & MD_FLAG_TABLES)) {
+        parser_flags += MD_FLAG_TABLES;
+    }
+    
+    if (strikethrough && !(parser_flags & MD_FLAG_STRIKETHROUGH)) {
+        parser_flags += MD_FLAG_STRIKETHROUGH;
+    }
+    
+    if (permissive_www_autolinks && !(parser_flags & MD_FLAG_PERMISSIVEWWWAUTOLINKS)) {
+        parser_flags += MD_FLAG_PERMISSIVEWWWAUTOLINKS;
+    }
+
+    if (tasklists && !(parser_flags & MD_FLAG_TASKLISTS)) {
+        parser_flags += MD_FLAG_TASKLISTS;
+    }
+    
+    if (latex_math_spans && !(parser_flags & MD_FLAG_LATEXMATHSPANS)) {
+        parser_flags += MD_FLAG_LATEXMATHSPANS;
+    }
+    
+    if (wikilinks && !(parser_flags & MD_FLAG_WIKILINKS)) {
+        parser_flags += MD_FLAG_WIKILINKS;
+    }
+    
+    if (underline && !(parser_flags & MD_FLAG_UNDERLINE)) {
+        parser_flags += MD_FLAG_UNDERLINE;
     }
 
     self->parser_flags = parser_flags;

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -266,6 +266,8 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
     unsigned int latex_math_spans = 0;
     unsigned int wikilinks = 0;
     unsigned int underline = 0;
+    unsigned int permissive_auto_links = 0;
+    unsigned int no_html = 0;
 
     static char *kwlist[] = {
         "parser_flags",
@@ -283,9 +285,11 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
         "latex_math_spans",
         "wikilinks",
         "underline",
+        "permissive_auto_links",
+        "no_html",
         NULL
     };
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I$pppppppppppppp", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I$pppppppppppppppp", kwlist,
                                      &parser_flags, &collapse_whitespace,
                                      &permissive_atx_headers,
                                      &permissive_url_autolinks,
@@ -293,7 +297,8 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
                                      &no_indented_code_blocks, &no_html_blocks,
                                      &no_html_spans, &tables, &strikethrough,
                                      &permissive_www_autolinks, &tasklists,
-                                     &latex_math_spans, &wikilinks, &underline)) {
+                                     &latex_math_spans, &wikilinks, &underline,
+                                     &permissive_auto_links, &no_html)) {
         return -1;
     }
 
@@ -351,6 +356,14 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
 
     if (underline) {
         parser_flags |= MD_FLAG_UNDERLINE;
+    }
+
+    if (permissive_auto_links) {
+        parser_flags |= MD_FLAG_PERMISSIVEAUTOLINKS;
+    }
+
+    if (no_html) {
+        parser_flags |= MD_FLAG_NOHTML;
     }
 
     self->parser_flags = parser_flags;

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -268,6 +268,7 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
     unsigned int underline = 0;
     unsigned int permissive_auto_links = 0;
     unsigned int no_html = 0;
+    unsigned int dialect_github = 0;
 
     static char *kwlist[] = {
         "parser_flags",
@@ -287,9 +288,10 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
         "underline",
         "permissive_auto_links",
         "no_html",
+        "dialect_github",
         NULL
     };
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I$pppppppppppppppp", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|I$ppppppppppppppppp", kwlist,
                                      &parser_flags, &collapse_whitespace,
                                      &permissive_atx_headers,
                                      &permissive_url_autolinks,
@@ -298,7 +300,8 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
                                      &no_html_spans, &tables, &strikethrough,
                                      &permissive_www_autolinks, &tasklists,
                                      &latex_math_spans, &wikilinks, &underline,
-                                     &permissive_auto_links, &no_html)) {
+                                     &permissive_auto_links, &no_html,
+                                     &dialect_github)) {
         return -1;
     }
 
@@ -364,6 +367,10 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
 
     if (no_html) {
         parser_flags |= MD_FLAG_NOHTML;
+    }
+
+    if (dialect_github) {
+        parser_flags |= MD_DIALECT_GITHUB;
     }
 
     self->parser_flags = parser_flags;

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -129,12 +129,155 @@ typedef struct {
 static int HTMLRenderer_init(HTMLRendererObject *self, PyObject *args,
         PyObject *kwds) {
     unsigned int parser_flags = 0;
+    unsigned int collapse_whitespace = 0;
+    unsigned int permissive_atx_headers = 0;
+    unsigned int permissive_url_autolinks = 0;
+    unsigned int permissive_email_autolinks = 0;
+    unsigned int no_indented_code_blocks = 0;
+    unsigned int no_html_blocks = 0;
+    unsigned int no_html_spans = 0;
+    unsigned int tables = 0;
+    unsigned int strikethrough = 0;
+    unsigned int permissive_www_autolinks = 0;
+    unsigned int tasklists = 0;
+    unsigned int latex_math_spans = 0;
+    unsigned int wikilinks = 0;
+    unsigned int underline = 0;
+    unsigned int permissive_auto_links = 0;
+    unsigned int no_html = 0;
+    unsigned int dialect_github = 0;
+
     unsigned int renderer_flags = 0;
-    
-    static char *kwlist[] = {"parser_flags", "renderer_flags", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|II", kwlist,
-            &parser_flags, &renderer_flags)) {
+    unsigned int debug = 0;
+    unsigned int verbatim_entities = 0;
+    unsigned int skip_utf8_bom = 0;
+    unsigned int xhtml = 0;
+
+    static char *kwlist[] = {
+        "parser_flags",
+        "renderer_flags",
+        "collapse_whitespace",
+        "permissive_atx_headers",
+        "permissive_url_autolinks",
+        "permissive_email_autolinks",
+        "no_indented_code_blocks",
+        "no_html_blocks",
+        "no_html_spans",
+        "tables",
+        "strikethrough",
+        "permissive_www_autolinks",
+        "tasklists",
+        "latex_math_spans",
+        "wikilinks",
+        "underline",
+        "permissive_auto_links",
+        "no_html",
+        "dialect_github",
+        "debug",
+        "verbatim_entities",
+        "skip_utf8_bom",
+        "xhtml",
+        NULL,
+    };
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|II$pppppppppppppppppppp",
+                                     kwlist, &parser_flags, &renderer_flags,
+                                     &collapse_whitespace,
+                                     &permissive_atx_headers,
+                                     &permissive_url_autolinks,
+                                     &permissive_email_autolinks,
+                                     &no_indented_code_blocks, &no_html_blocks,
+                                     &no_html_spans, &tables, &strikethrough,
+                                     &permissive_www_autolinks, &tasklists,
+                                     &latex_math_spans, &wikilinks, &underline,
+                                     &permissive_auto_links, &no_html,
+                                     &dialect_github,
+                                     &debug, &verbatim_entities,
+                                     &skip_utf8_bom, &xhtml)) {
         return -1;
+    }
+
+    if (collapse_whitespace) {
+        parser_flags |= MD_FLAG_COLLAPSEWHITESPACE;
+    }
+
+    if (permissive_atx_headers) {
+        parser_flags |= MD_FLAG_PERMISSIVEATXHEADERS;
+    }
+
+    if (permissive_url_autolinks) {
+        parser_flags |= MD_FLAG_PERMISSIVEURLAUTOLINKS;
+    }
+
+    if (permissive_email_autolinks) {
+        parser_flags |= MD_FLAG_PERMISSIVEEMAILAUTOLINKS;
+    }
+
+    if (no_indented_code_blocks) {
+        parser_flags |= MD_FLAG_NOINDENTEDCODEBLOCKS;
+    }
+
+    if (no_html_blocks) {
+        parser_flags |= MD_FLAG_NOHTMLBLOCKS;
+    }
+
+    if (no_html_spans) {
+        parser_flags |= MD_FLAG_NOHTMLSPANS;
+    }
+
+    if (tables) {
+        parser_flags |= MD_FLAG_TABLES;
+    }
+
+    if (strikethrough) {
+        parser_flags |= MD_FLAG_STRIKETHROUGH;
+    }
+
+    if (permissive_www_autolinks) {
+        parser_flags |= MD_FLAG_PERMISSIVEWWWAUTOLINKS;
+    }
+
+    if (tasklists) {
+        parser_flags |= MD_FLAG_TASKLISTS;
+    }
+
+    if (latex_math_spans) {
+        parser_flags |= MD_FLAG_LATEXMATHSPANS;
+    }
+
+    if (wikilinks) {
+        parser_flags |= MD_FLAG_WIKILINKS;
+    }
+
+    if (underline) {
+        parser_flags |= MD_FLAG_UNDERLINE;
+    }
+
+    if (permissive_auto_links) {
+        parser_flags |= MD_FLAG_PERMISSIVEAUTOLINKS;
+    }
+
+    if (no_html) {
+        parser_flags |= MD_FLAG_NOHTML;
+    }
+
+    if (dialect_github) {
+        parser_flags |= MD_DIALECT_GITHUB;
+    }
+
+    if (debug) {
+        renderer_flags |= MD_HTML_FLAG_DEBUG;
+    }
+
+    if (verbatim_entities) {
+        renderer_flags |= MD_HTML_FLAG_VERBATIM_ENTITIES;
+    }
+
+    if (skip_utf8_bom) {
+        renderer_flags |= MD_HTML_FLAG_SKIP_UTF8_BOM;
+    }
+
+    if (xhtml) {
+        renderer_flags |= MD_HTML_FLAG_XHTML;
     }
 
     self->parser_flags = parser_flags;
@@ -304,7 +447,7 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
                                      &dialect_github)) {
         return -1;
     }
-
+    
     if (collapse_whitespace) {
         parser_flags |= MD_FLAG_COLLAPSEWHITESPACE;
     }

--- a/src/pymd4c.c
+++ b/src/pymd4c.c
@@ -252,21 +252,21 @@ typedef struct {
 static int GenericParser_init(GenericParserObject *self, PyObject *args,
         PyObject *kwds) {
     unsigned int parser_flags = 0;
-    unsigned short int collapse_whitespace = 0;
-    unsigned short int permissive_atx_headers = 0;
-    unsigned short int permissive_url_autolinks = 0;
-    unsigned short int permissive_email_autolinks = 0;
-    unsigned short int no_indented_code_blocks = 0;
-    unsigned short int no_html_blocks = 0;
-    unsigned short int no_html_spans = 0;
-    unsigned short int tables = 0;
-    unsigned short int strikethrough = 0;
-    unsigned short int permissive_www_autolinks = 0;
-    unsigned short int tasklists = 0;
-    unsigned short int latex_math_spans = 0;
-    unsigned short int wikilinks = 0;
-    unsigned short int underline = 0;
-    
+    unsigned int collapse_whitespace = 0;
+    unsigned int permissive_atx_headers = 0;
+    unsigned int permissive_url_autolinks = 0;
+    unsigned int permissive_email_autolinks = 0;
+    unsigned int no_indented_code_blocks = 0;
+    unsigned int no_html_blocks = 0;
+    unsigned int no_html_spans = 0;
+    unsigned int tables = 0;
+    unsigned int strikethrough = 0;
+    unsigned int permissive_www_autolinks = 0;
+    unsigned int tasklists = 0;
+    unsigned int latex_math_spans = 0;
+    unsigned int wikilinks = 0;
+    unsigned int underline = 0;
+
     static char *kwlist[] = {
         "parser_flags",
         "collapse_whitespace",
@@ -296,61 +296,61 @@ static int GenericParser_init(GenericParserObject *self, PyObject *args,
                                      &latex_math_spans, &wikilinks, &underline)) {
         return -1;
     }
-    
-    if (collapse_whitespace && !(parser_flags & MD_FLAG_COLLAPSEWHITESPACE)) {
-        parser_flags += MD_FLAG_COLLAPSEWHITESPACE;
-    }
-    
-    if (permissive_atx_headers && !(parser_flags & MD_FLAG_PERMISSIVEATXHEADERS)) {
-        parser_flags += MD_FLAG_PERMISSIVEATXHEADERS;
-    }
-    
-    if (permissive_url_autolinks && !(parser_flags & MD_FLAG_PERMISSIVEURLAUTOLINKS)) {
-        parser_flags += MD_FLAG_PERMISSIVEURLAUTOLINKS;
-    }
-    
-    if (permissive_email_autolinks && !(parser_flags & MD_FLAG_PERMISSIVEEMAILAUTOLINKS)) {
-        parser_flags += MD_FLAG_PERMISSIVEEMAILAUTOLINKS;
-    }
-    
-    if (no_indented_code_blocks && !(parser_flags & MD_FLAG_NOINDENTEDCODEBLOCKS)) {
-        parser_flags += MD_FLAG_NOINDENTEDCODEBLOCKS;
-    }
-    
-    if (no_html_blocks && !(parser_flags & MD_FLAG_NOHTMLBLOCKS)) {
-        parser_flags += MD_FLAG_NOHTMLBLOCKS;
-    }
-    
-    if (no_html_spans && !(parser_flags & MD_FLAG_NOHTMLSPANS)) {
-        parser_flags += MD_FLAG_NOHTMLSPANS;
-    }
-    
-    if (tables && !(parser_flags & MD_FLAG_TABLES)) {
-        parser_flags += MD_FLAG_TABLES;
-    }
-    
-    if (strikethrough && !(parser_flags & MD_FLAG_STRIKETHROUGH)) {
-        parser_flags += MD_FLAG_STRIKETHROUGH;
-    }
-    
-    if (permissive_www_autolinks && !(parser_flags & MD_FLAG_PERMISSIVEWWWAUTOLINKS)) {
-        parser_flags += MD_FLAG_PERMISSIVEWWWAUTOLINKS;
+
+    if (collapse_whitespace) {
+        parser_flags |= MD_FLAG_COLLAPSEWHITESPACE;
     }
 
-    if (tasklists && !(parser_flags & MD_FLAG_TASKLISTS)) {
-        parser_flags += MD_FLAG_TASKLISTS;
+    if (permissive_atx_headers) {
+        parser_flags |= MD_FLAG_PERMISSIVEATXHEADERS;
     }
-    
-    if (latex_math_spans && !(parser_flags & MD_FLAG_LATEXMATHSPANS)) {
-        parser_flags += MD_FLAG_LATEXMATHSPANS;
+
+    if (permissive_url_autolinks) {
+        parser_flags |= MD_FLAG_PERMISSIVEURLAUTOLINKS;
     }
-    
-    if (wikilinks && !(parser_flags & MD_FLAG_WIKILINKS)) {
-        parser_flags += MD_FLAG_WIKILINKS;
+
+    if (permissive_email_autolinks) {
+        parser_flags |= MD_FLAG_PERMISSIVEEMAILAUTOLINKS;
     }
-    
-    if (underline && !(parser_flags & MD_FLAG_UNDERLINE)) {
-        parser_flags += MD_FLAG_UNDERLINE;
+
+    if (no_indented_code_blocks) {
+        parser_flags |= MD_FLAG_NOINDENTEDCODEBLOCKS;
+    }
+
+    if (no_html_blocks) {
+        parser_flags |= MD_FLAG_NOHTMLBLOCKS;
+    }
+
+    if (no_html_spans) {
+        parser_flags |= MD_FLAG_NOHTMLSPANS;
+    }
+
+    if (tables) {
+        parser_flags |= MD_FLAG_TABLES;
+    }
+
+    if (strikethrough) {
+        parser_flags |= MD_FLAG_STRIKETHROUGH;
+    }
+
+    if (permissive_www_autolinks) {
+        parser_flags |= MD_FLAG_PERMISSIVEWWWAUTOLINKS;
+    }
+
+    if (tasklists) {
+        parser_flags |= MD_FLAG_TASKLISTS;
+    }
+
+    if (latex_math_spans) {
+        parser_flags |= MD_FLAG_LATEXMATHSPANS;
+    }
+
+    if (wikilinks) {
+        parser_flags |= MD_FLAG_WIKILINKS;
+    }
+
+    if (underline) {
+        parser_flags |= MD_FLAG_UNDERLINE;
     }
 
     self->parser_flags = parser_flags;


### PR DESCRIPTION
Closes #13

### Progress

- [x] Implement `GenericParser` flag kwargs.
- [x] Implement `GenericParser` combination option flags kwargs.
- [x] Implement `GenericParser` dialect option flags kwargs.
- [x] Implement `HTMLRenderer` option flag kwargs.
- [x] Document `GenericParser` flag kwargs.
- [x] Document `HTMLRenderer` flag kwargs.

+ What do you think about documentation of flag kwargs? Creating a table of correspondences (Flag, Kwarg and Description) or simply placing after option flags names?
+ What do you think about the implementation in this pull?

I'm using next script to test it:

<details>

```python
import pytest

import md4c


def default_enter_block_callback(block, details):
    print("ENTER BLOCK:", block.name, details)


def default_leave_block_callback(block, details):
    print("LEAVE BLOCK:", block.name, details)


def default_enter_span_callback(span, details):
    print("ENTER SPAN:", span.name, details)


def default_leave_span_callback(span, details):
    print("LEAVE SPAN:", span.name, details)


def default_text_callback(block, text):
    print("TEXT:", block.name, text)


def _build_callbacks(**callbacks):
    for callback_name in [
        "enter_block",
        "leave_block",
        "enter_span",
        "leave_span",
        "text",
    ]:
        if callback_name not in callbacks:
            callbacks[callback_name] = globals()["default_%s_callback" % callback_name]
        yield callbacks[callback_name]


def _build_test(markdown_input, callbacks_dict, parser_flag=None, parser_kwargs={}):
    parser_args = [] if parser_flag is None else [parser_flag]
    generic_parser = md4c.GenericParser(*parser_args, **parser_kwargs)
    generic_parser.parse(markdown_input, *_build_callbacks(**callbacks_dict))


def _run_params_consistency_tests(
    markdown_input, callbacks_dict, flag_kwargname, flag_name
):
    for flag_attrname_schema in ["MD_FLAG_%s", "MD_%s"]:
        try:
            flag_attrname = flag_attrname_schema % flag_name
            flag = getattr(md4c, flag_attrname)
        except AttributeError:
            continue

    # flag kwarg name
    print("\n\n- kwarg:", flag_kwargname)
    _build_test(markdown_input, callbacks_dict, parser_kwargs={flag_kwargname: True})

    # MD_FLAG
    print("\n- flag: ", flag_attrname)
    _build_test(markdown_input, callbacks_dict, parser_flag=flag)

    # flag kwarg name + MD_FLAG
    print("\n- %s + %s" % (flag_kwargname, flag_attrname))
    _build_test(
        markdown_input,
        callbacks_dict,
        parser_kwargs={flag_kwargname: True},
        parser_flag=flag,
    )

    # without flags nor kwargs
    print("\n- !%s && !%s -> Error" % (flag_kwargname, flag_attrname))
    with pytest.raises(AssertionError):
        _build_test(markdown_input, callbacks_dict)


def test_collapsewhitespace():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text in ["Text with", " ", "whitespace collapsed"]

    _run_params_consistency_tests(
        "Text with     whitespace collapsed",
        dict(text=text_callback),
        "collapse_whitespace",
        "COLLAPSEWHITESPACE",
    )


def test_permissive_atx_headers():
    def enter_block_callback(block, details):
        default_enter_block_callback(block, details)
        assert block.value in [md4c.BlockType.DOC, md4c.BlockType.H]
        if block.value == md4c.BlockType.H:
            assert details["level"] == 1

    def text_callback(block, text):
        assert text == "Header 1"

    _run_params_consistency_tests(
        "#Header 1",
        dict(enter_block=enter_block_callback, text=text_callback),
        "permissive_atx_headers",
        "PERMISSIVEATXHEADERS",
    )


def test_permissive_url_autolinks():
    def enter_span_callback(span, details):
        default_enter_span_callback(span, details)
        assert span.value == md4c.SpanType.A
        assert details["href"][0][1] == "https://nowhere.none"

    def text_callback(block, text):
        default_text_callback(block, text)
        assert text in ["Some text with ", "https://nowhere.none"]

    _run_params_consistency_tests(
        "Some text with https://nowhere.none",
        dict(enter_span=enter_span_callback, text=text_callback),
        "permissive_url_autolinks",
        "PERMISSIVEURLAUTOLINKS",
    )


def test_permissive_email_autolinks():
    def enter_span_callback(span, details):
        default_enter_span_callback(span, details)
        assert span.value == md4c.SpanType.A
        assert details["href"][0][1] == "mailto:mailaddress@provider.none"

    def text_callback(block, text):
        default_text_callback(block, text)
        assert text in ["Some text with ", "mailaddress@provider.none"]

    _run_params_consistency_tests(
        "Some text with mailaddress@provider.none",
        dict(enter_span=enter_span_callback, text=text_callback),
        "permissive_email_autolinks",
        "PERMISSIVEEMAILAUTOLINKS",
    )


def test_no_indented_code_blocks():
    def enter_block_callback(block, details):
        default_enter_block_callback(block, details)
        assert block.value in [md4c.BlockType.DOC, md4c.BlockType.H,
                               md4c.BlockType.P]

    _run_params_consistency_tests(
        "# Header\n\n    Indented code block\n\n",
        dict(enter_block=enter_block_callback),
        "no_indented_code_blocks",
        "NOINDENTEDCODEBLOCKS",
    )


def test_no_html_blocks():
    def enter_block_callback(block, details):
        default_enter_block_callback(block, details)
        assert block.value in [md4c.BlockType.DOC, md4c.BlockType.P]

    _run_params_consistency_tests(
        "<div>some HTML</div>\n",
        dict(enter_block=enter_block_callback),
        "no_html_blocks",
        "NOHTMLBLOCKS",
    )


def test_no_html_spans():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert block.value == md4c.TextType.NORMAL
        assert text == "Some text with <span>HTML</span>"

    _run_params_consistency_tests(
        "Some text with <span>HTML</span>\n",
        dict(text=text_callback),
        "no_html_spans",
        "NOHTMLSPANS",
    )


def test_tables():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert block.value != md4c.TextType.BR
        assert text != "| :------: | -------: |"

    markdown_input = """-----------------------
| Header A | Header B |
| :------: | -------: |
| Body A   | Body B   |
-----------------------
"""

    _run_params_consistency_tests(
        markdown_input, dict(text=text_callback), "tables", "TABLES"
    )


def test_strikethrough():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text != "Some text ~~striked~~."

    _run_params_consistency_tests(
        "Some text ~~striked~~.",
        dict(text=text_callback),
        "strikethrough",
        "STRIKETHROUGH",
    )


def test_permissive_www_autolinks():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text != "Some text with link to www.nowhere.none"

    _run_params_consistency_tests(
        "Some text with link to www.nowhere.none",
        dict(text=text_callback),
        "permissive_www_autolinks",
        "PERMISSIVEWWWAUTOLINKS",
    )


def test_tasklists():
    def enter_block_callback(block, details):
        default_enter_block_callback(block, details)
        assert block.value in [md4c.BlockType.DOC, md4c.BlockType.UL,
                               md4c.BlockType.LI]
        if block.value == md4c.BlockType.LI:
            assert details["is_task"] is True
            assert details["task_mark"] in [" ", "x"]

    _run_params_consistency_tests(
        "- [ ] Task A\n- [x] Task B\n",
        dict(enter_block=enter_block_callback),
        "tasklists",
        "TASKLISTS",
    )


def test_latex_math_spans():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text != "Some text with $latexMagic$."

    _run_params_consistency_tests(
        "Some text with $latexMagic$.",
        dict(text=text_callback),
        "latex_math_spans",
        "LATEXMATHSPANS",
    )


def test_wikilinks():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text != "Some text with [[target|text]]."

    _run_params_consistency_tests(
        "Some text with [[target|text]].",
        dict(text=text_callback),
        "wikilinks",
        "WIKILINKS",
    )


def test_underline():
    def enter_span_callback(span, details):
        default_enter_span_callback(span, details)
        assert span.value != md4c.SpanType.EM

    _run_params_consistency_tests(
        "Some text _underlined_.",
        dict(enter_span=enter_span_callback),
        "underline",
        "UNDERLINE",
    )


def test_generic_parser_combined_kwargs():
    def enter_span_callback(span, details):
        default_enter_span_callback(span, details)
        assert span.value != md4c.SpanType.EM

    def text_callback(block, text):
        default_text_callback(block, text)
        assert " and other ~~striked~~." not in text

    generic_parser = md4c.GenericParser(strikethrough=True, underline=True)
    generic_parser.parse(
        "Some text _underlined_ and other ~~striked~~.",
        *_build_callbacks(**dict(text=text_callback,
                                 enter_span=enter_span_callback))
    )


def test_permissive_autolinks():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text not in ["Text with www.autolink.none",
                            "Text with https://url-autolink.none",
                            "Text with mailaddress@provider.none"]

    _run_params_consistency_tests(
        ("Text with www.autolink.none\n\n"
         "Text with https://url-autolink.none\n\n"
         "Text with mailaddress@provider.none\n"),
        dict(text=text_callback),
        "permissive_auto_links",
        "PERMISSIVEAUTOLINKS",
    )


def test_no_html():
    def enter_block_callback(block, details):
        default_enter_block_callback(block, details)
        assert block.value in [md4c.BlockType.DOC, md4c.BlockType.P]

    def text_callback(block, text):
        default_text_callback(block, text)
        assert text in ["Some text with <span>HTML span</span>.",
                        "<div>HTML block</div>"]

    _run_params_consistency_tests(
        "<div>HTML block</div>\n\nSome text with <span>HTML span</span>.\n",
        dict(enter_block=enter_block_callback,
             text=text_callback),
        "no_html",
        "NOHTML",
    )


def test_dialect_github():
    def text_callback(block, text):
        default_text_callback(block, text)
        assert text != "| :------: | -------: |"

    markdown_input = '''
-----------------------
| Header A | Header B |
| :------: | -------: |
| Body A   | Body B   |
-----------------------
'''
    _run_params_consistency_tests(
        markdown_input,
        dict(text=text_callback),
        "dialect_github",
        "DIALECT_GITHUB",
    )
```

</details>